### PR TITLE
Move dependencies to requirements.txt in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You can easily run the API locally (`uv run dev`), which allows for a nice devel
 simple-api-lambda-cdk/
 ├── app/                    # FastAPI application
 │   ├── handler.py          # Lambda handler and dev server
+│   ├── requirements.txt    # Application runtime dependencies
 │   ├── models/             # Pydantic models
 │   ├── routes/             # API route definitions
 │   │   ├── greetings/      # Greeting endpoints
@@ -41,6 +42,8 @@ simple-api-lambda-cdk/
    ```bash
    uv sync
    ```
+
+   The Lambda application's runtime dependencies are defined in `app/requirements.txt`. The CDK bundling step installs from this file so the application folder can be managed independently (for example, as a Git submodule).
 
 2. **Bootstrap CDK (if not already done):**
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.115.0
+mangum>=0.17.0
+uvicorn>=0.37.0
+scalar-fastapi>=1.4.3
+requests>=2.31.0
+types-requests>=2.32.4.20250913
+pydantic[email]

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -42,7 +42,7 @@ class SimpleLambdaStack(Stack):
                         "-c",
                         # Exit the script if any command fails (set -e)
                         "set -e; \
-                        pip install --no-cache-dir --target /asset-output --platform linux_x86_64 --only-binary=:all: . --group lambda; \
+                        pip install --no-cache-dir --target /asset-output --platform linux_x86_64 --only-binary=:all: -r app/requirements.txt; \
                         cp -r app /asset-output",
                     ],
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,6 @@ start = "app.handler:start"
 default-groups = "all"
 
 [dependency-groups]
-# Lambda runtime dependencies
-lambda = [
-    "requests>=2.31.0",
-    "fastapi>=0.115.0",
-    "mangum>=0.17.0",
-    "uvicorn>=0.37.0",
-    "scalar-fastapi>=1.4.3",
-    "types-requests>=2.32.4.20250913",
-    "pydantic[email]",
-]
 
 # Development dependencies
 dev = [


### PR DESCRIPTION
- [Move dependencies to requirements.txt in app](https://github.com/owen-hayes/simple-api-lambda-cdk/commit/a918420229d16ca6f220b8cf1d391c39b5f1f450)

**Resolves #1**